### PR TITLE
On Windows, unescaped $file in regex pattern causes tests to fail

### DIFF
--- a/t/01_info.t
+++ b/t/01_info.t
@@ -25,7 +25,7 @@ my($si) = grep {
 	} @info;
 
 
-like __FILE__, qr/$si->[1]/, 'state info'
+like __FILE__, qr/\Q$si->[1]\E/, 'state info'
 	or diag(Dumper \@info);
 
 @info = leaked_info{

--- a/t/11_logfp.t
+++ b/t/11_logfp.t
@@ -21,22 +21,22 @@ $_ = 'defsv';
 
 my $file = __FILE__;
 t(-simple);
-like $content,   qr/from $file line 15\./, -simple;
+like $content,   qr/from \Q$file\E line 15\./, -simple;
 unlike $content, qr/15:\t\tpush \@array/, -lines;
 unlike $content, qr/REFCNT/, -sv_dump;
 
 t(-lines);
-like $content, qr/from $file line 15\./, -simple;
+like $content, qr/from \Q$file\E line 15\./, -simple;
 like $content, qr/15:\t\tpush \@array/, -lines;
 unlike $content, qr/REFCNT/, -sv_dump;
 
 t(-sv_dump);
-like $content, qr/from $file line 15\./, -simple;
+like $content, qr/from \Q$file\E line 15\./, -simple;
 unlike $content, qr/15:\t\tpush \@array/, -lines;
 like $content, qr/REFCNT/, -sv_dump;
 
 t(-verbose);
-like $content, qr/from $file line 15\./, -simple;
+like $content, qr/from \Q$file\E line 15\./, -simple;
 like $content, qr/15:\t\tpush \@array/, -lines;
 like $content, qr/REFCNT/, -sv_dump;
 


### PR DESCRIPTION
Wrap each filename interpolated into a regex pattern with \Q ... \E
