### PR TITLE
perl-5.26.0 compatibility.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use lib '.';
 use inc::Module::Install;
 
 name 'Test-LeakTrace';

--- a/t/13_do.t
+++ b/t/13_do.t
@@ -6,7 +6,7 @@ use Test::More tests => 1;
 use Test::LeakTrace;
 
 sub foo{
-	do 't/lib/foo.pl';
+	do './t/lib/foo.pl';
 }
 
 


### PR DESCRIPTION
In perl-5.26 and later, '.' will no longer be found in @INC by default.  This
patch enables correct use of inc::Module::Install and 'do $file'.

For: https://rt.cpan.org/Ticket/Display.html?id=120420