### PR TITLE
Add warnings to Test::LeakTrace::Script

### DIFF
--- a/lib/Test/LeakTrace/Script.pm
+++ b/lib/Test/LeakTrace/Script.pm
@@ -1,6 +1,7 @@
 package Test::LeakTrace::Script;
 
 use strict;
+use warnings;
 
 use Test::LeakTrace ();
 


### PR DESCRIPTION
I've been assigned this dist as part of the [CPAN PR Challenge](http://cpan-prc.org) - thanks for participating.

Here is a trivial change to Test::LeakTrace::Script to use warnings as recommended by CPANTS. The test suite shows no new warnings for me when run after this change.